### PR TITLE
Pin mcd CLI version explicitly

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,13 +1,11 @@
 { pkgs ? import (fetchGit {
     url = https://github.com/dapphub/dapptools.git;
-    rev = dapptools-rev;
+    rev = "6943c76bfb8e0b1fce54c3d9bba6f0f7e50d2f5c";
   }) {}
-, dapptools-rev ? "6943c76bfb8e0b1fce54c3d9bba6f0f7e50d2f5c"
 , mcd-cli ? pkgs.callPackage (import (fetchGit {
     url = https://github.com/makerdao/mcd-cli.git;
-    rev = mcd-cli-rev;
+    rev = "86842b49defa53301ac0019f7d5994859bb3e1e9";
   })) {}
-, mcd-cli-rev ? "86842b49defa53301ac0019f7d5994859bb3e1e9"
 , eth_from
 , eth_keystore ? ~/.dapp/testnet/8545/keystore
 , eth_password ? "/dev/null"
@@ -16,7 +14,7 @@
 pkgs.mkShell {
   buildInputs = with pkgs; [
     dapp ethsign seth mcd-cli
-    bc jq coreutils findutils procps
+    bc jq coreutils
   ];
 
   ETH_FROM="${eth_from}";

--- a/shell.nix
+++ b/shell.nix
@@ -1,15 +1,23 @@
 { pkgs ? import (fetchGit {
     url = https://github.com/dapphub/dapptools.git;
-    ref = dapptoolsRev;
+    rev = dapptools-rev;
   }) {}
-, dapptoolsRev ? "6943c76bfb8e0b1fce54c3d9bba6f0f7e50d2f5c"
+, dapptools-rev ? "6943c76bfb8e0b1fce54c3d9bba6f0f7e50d2f5c"
+, mcd-cli ? pkgs.callPackage (import (fetchGit {
+    url = https://github.com/makerdao/mcd-cli.git;
+    rev = mcd-cli-rev;
+  })) {}
+, mcd-cli-rev ? "86842b49defa53301ac0019f7d5994859bb3e1e9"
 , eth_from
 , eth_keystore ? ~/.dapp/testnet/8545/keystore
 , eth_password ? "/dev/null"
 }:
 
 pkgs.mkShell {
-  buildInputs = with pkgs; [ bc dapp jq ethsign seth ];
+  buildInputs = with pkgs; [
+    dapp ethsign seth mcd-cli
+    bc jq coreutils findutils procps
+  ];
 
   ETH_FROM="${eth_from}";
   ETH_KEYSTORE="${eth_keystore}";


### PR DESCRIPTION
A first iteration of reaching reproducibility of deployment script dependencies discussed here: https://github.com/makerdao/smart-contracts-team-pm/issues/141

First step is to explicitly add and pin MakerDAO specific dependencies.