### PR TITLE
Add dss deploy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "contracts/token-faucet"]
 	path = contracts/token-faucet
 	url = https://github.com/makerdao/token-faucet
+[submodule "contracts/dss-deploy"]
+	path = contracts/dss-deploy
+	url = https://github.com/makerdao/dss-deploy

--- a/base-deploy
+++ b/base-deploy
@@ -57,7 +57,7 @@ dapp build
 PROXY_FACTORY=$(dapp create DSProxyFactory)
 PROXY_REGISTRY=$(dapp create ProxyRegistry "$PROXY_FACTORY")
 
-cd ../dss-proxy-actions/lib/dss-cdp-manager/lib/dss-deploy
+cd ../dss-deploy
 
 # Deploy Fabs (no solc optimization)
 ./bin/deploy-fab


### PR DESCRIPTION
Treats `dss-deploy` as a direct dependency.

When the version of `dss-deploy` needs to be updated, it makes little sense to do it in `dss-cdp-manager`, since that project only uses it as a way to facilitate testing.