### PR TITLE
nix: use tag instead of commit hash

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 { pkgs ? import (fetchGit {
     url = https://github.com/dapphub/dapptools.git;
-    rev = "6943c76bfb8e0b1fce54c3d9bba6f0f7e50d2f5c";
+    ref = "dapp/0.16.0";
   }) {}
 , mcd-cli ? pkgs.callPackage (import (fetchGit {
     url = https://github.com/makerdao/mcd-cli.git;

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
-{ pkgs ? import (fetchGit {
-    url = https://github.com/dapphub/dapptools.git;
-    ref = "dapp/0.16.0";
+{ pkgs ? import (fetchTarball {
+    url = https://github.com/dapphub/dapptools/archive/dapp/0.16.0.tar.gz;
+    sha256 = "06k4grj8spdxg5758sqz908f92hp707khsnb2dygsl0229z4rhxl";
   }) {}
 , mcd-cli ? pkgs.callPackage (import (fetchGit {
     url = https://github.com/makerdao/mcd-cli.git;


### PR DESCRIPTION
More legible and less likely to trigger the "ambiguous refname"
conflict.