### PR TITLE
Add `dss-deploy/bin` to PATH

### DIFF
--- a/base-deploy
+++ b/base-deploy
@@ -127,47 +127,9 @@ PROXY_DEPLOYER=0x"$(seth call "$PROXY_REGISTRY" 'proxies(address)(address)' "$ET
 seth send "$MCD_ADM" 'vote(address[] memory)' ["${PROXY_DEPLOYER#0x}"]
 seth send "$MCD_ADM" 'lift(address)' "$PROXY_DEPLOYER"
 
-# Copy abi files
+# Copy dss-deploy abi files
 mkdir -p "$OUT_DIR"/abi
-cp "$DAPP_LIB"/multicall/out/Multicall.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/ds-guard/out/DSGuard.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/ds-chief/out/DSToken.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/ds-chief/out/DSChief.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/vote-proxy/out/VoteProxy.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/vote-proxy/out/VoteProxyFactory.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-proxy-actions/out/DssProxyActions.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-proxy-actions/out/DssCdpManager.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-proxy-actions/out/GetCdps.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-proxy-actions/out/DssDeploy.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-proxy-actions/out/Vat.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-proxy-actions/out/Jug.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-proxy-actions/out/Cat.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-proxy-actions/out/Vow.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-proxy-actions/out/Flipper.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-proxy-actions/out/Flopper.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-proxy-actions/out/Flapper.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-proxy-actions/out/DaiJoin.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-proxy-actions/out/GemJoin.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-proxy-actions/out/Spotter.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-proxy-actions/out/Pot.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/proxy-registry/out/DSProxy.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/proxy-registry/out/DSProxyFactory.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/proxy-registry/out/ProxyRegistry.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/token-faucet/out/TokenFaucet.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-deploy/out/VatFab.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-deploy/out/JugFab.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-deploy/out/VowFab.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-deploy/out/CatFab.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-deploy/out/DaiFab.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-deploy/out/DaiJoinFab.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-deploy/out/FlapFab.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-deploy/out/FlopFab.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-deploy/out/FlipFab.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-deploy/out/SpotFab.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-deploy/out/PotFab.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-deploy/out/PauseFab.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-deploy/out/DSPause.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/dss-deploy/out/GovActions.abi "$OUT_DIR"/abi
+cp -f "$DAPP_LIB"/dss-deploy/out/*.abi "$OUT_DIR"/abi
 
 for token in $tokens; do
     ILKS_VARS+=",

--- a/base-deploy
+++ b/base-deploy
@@ -128,8 +128,7 @@ seth send "$MCD_ADM" 'vote(address[] memory)' ["${PROXY_DEPLOYER#0x}"]
 seth send "$MCD_ADM" 'lift(address)' "$PROXY_DEPLOYER"
 
 # Copy dss-deploy abi files
-mkdir -p "$OUT_DIR"/abi
-cp -f "$DAPP_LIB"/dss-deploy/out/*.abi "$OUT_DIR"/abi
+copyAbis dss-deploy
 
 for token in $tokens; do
     ILKS_VARS+=",

--- a/base-deploy
+++ b/base-deploy
@@ -46,10 +46,10 @@ dappBuild proxy-registry
 PROXY_FACTORY=$(dappCreate proxy-registry DSProxyFactory)
 PROXY_REGISTRY=$(dappCreate proxy-registry ProxyRegistry "$PROXY_FACTORY")
 
-cd "$DAPP_LIB/dss-deploy"
+PATH="$DAPP_LIB/dss-deploy/bin:$PATH"
 
 # Deploy Fabs (no solc optimization)
-./bin/deploy-fab
+deploy-fab
 # shellcheck source=/dev/null
 . "load-fab-$(seth chain)"
 rm "load-fab-$(seth chain)"
@@ -58,7 +58,7 @@ rm "load-fab-$(seth chain)"
 export MCD_PAUSE_DELAY=0
 
 # Deploy MCD Core Contratcs (solc optimized)
-./bin/deploy-core
+deploy-core
 # shellcheck source=/dev/null
 . "load-mcd-$(seth chain)"
 rm "load-mcd-$(seth chain)"
@@ -75,7 +75,7 @@ for token in $tokens; do
             newToken=false
         fi
 
-        ./bin/deploy-ilk-"$(echo "$token" | tr '[:upper:]' '[:lower:]')" "$ilk"
+        deploy-ilk-"$(echo "$token" | tr '[:upper:]' '[:lower:]')" "$ilk"
 
         # shellcheck source=/dev/null
         . "load-ilk-$(echo "$token" | tr '[:upper:]' '[:lower:]')-$(echo "$ilk" | tr '[:upper:]' '[:lower:]')-$(seth chain)"

--- a/default.nix
+++ b/default.nix
@@ -37,14 +37,4 @@ in makerScriptPackage {
   extraBins = [
     dss-deploy'
   ];
-
-  # Patch scripts by removing `cd` commands and `./bin/` from `dss-deploy`
-  # script path.
-  patchBin = writeScript "remove-cd" ''
-    #!${stdenv.shell}
-    exec ${perl}/bin/perl -pe '
-      s|^(\s*)cd\s+[^\n\r;&\|]+|\1true|;
-      s|^(\s*)\./bin/||;
-    '
-  '';
 }

--- a/default.nix
+++ b/default.nix
@@ -37,4 +37,8 @@ in makerScriptPackage {
   extraBins = [
     dss-deploy'
   ];
+
+  scriptEnv = {
+    SKIP_BUILD = true;
+  };
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -45,6 +45,13 @@ addAddresses() {
     printf %s "$result" > "$OUT_DIR/addresses.json"
 }
 
+copyAbis() {
+  local lib; lib=$1
+  mkdir -p "$OUT_DIR/abi"
+  find "$DAPP_LIB/$lib/out" -name "*.abi" ! -name "*Test.abi" \
+    -exec cp -f {} "$OUT_DIR/abi" \;
+}
+
 dappBuild() {
   [[ -n $DAPP_SKIP_BUILD ]] && return
 
@@ -58,9 +65,7 @@ dappCreate() {
   local lib; lib=$1
   local class; class=$2
   DAPP_OUT="$DAPP_LIB/$lib/out" dapp create "$class" "${@:3}"
-  mkdir -p "$OUT_DIR/abi"
-  find "$DAPP_LIB/$lib/out" -name "*.abi" ! -name "*Test.abi" \
-    -exec cp -f {} "$OUT_DIR/abi" \;
+  copyAbis "$lib"
 }
 
 # Start verbose output

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -59,7 +59,8 @@ dappCreate() {
   local class; class=$2
   DAPP_OUT="$DAPP_LIB/$lib/out" dapp create "$class" "${@:3}"
   mkdir -p "$OUT_DIR/abi"
-  cp -f "$DAPP_LIB/$lib/out/*.abi" "$OUT_DIR/abi"
+  find "$DAPP_LIB/$lib/out" -name "*.abi" ! -name "*Test.abi" \
+    -exec cp -f {} "$OUT_DIR/abi" \;
 }
 
 # Start verbose output

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -3,6 +3,7 @@
 # Set fail flags
 set -eo pipefail
 
+# Set internal paths
 BIN_DIR=${BIN_DIR:-$(cd "${BASH_SOURCE[0]%/*}/.."&&pwd)}
 LIB_DIR=${LIB_DIR:-$BIN_DIR/lib}
 LIBEXEC_DIR=${LIBEXEC_DIR:-$BIN_DIR/scripts}
@@ -10,12 +11,7 @@ CONFIG_DIR=${CONFIG_DIR:-$BIN_DIR}
 
 DAPP_LIB=${DAPP_LIB:-$BIN_DIR/contracts}
 
-export OUT_DIR=${OUT_DIR:-$PWD/out}
-
-export ETH_GAS=7000000
-unset SOLC_FLAGS
-
-export CONFIG_FILE="${OUT_DIR}/config.json"
+# Declare functions
 
 setConfigStep() {
     CONFIG_STEP=${CONFIG_STEP:-"$1"}
@@ -50,7 +46,7 @@ addAddresses() {
 }
 
 dappBuild() {
-  test -n "$SKIP_BUILD" && return
+  [[ -n $DAPP_SKIP_BUILD ]] && return
 
   local lib; lib=$1
   (cd "$DAPP_LIB/$lib" || exit 1
@@ -68,3 +64,10 @@ dappCreate() {
 
 # Start verbose output
 set -x
+
+# Set exported variables
+export ETH_GAS=7000000
+unset SOLC_FLAGS
+
+export OUT_DIR=${OUT_DIR:-$PWD/out}
+export CONFIG_FILE="${OUT_DIR}/config.json"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -59,7 +59,7 @@ dappCreate() {
   local class; class=$2
   DAPP_OUT="$DAPP_LIB/$lib/out" dapp create "$class" "${@:3}"
   mkdir -p "$OUT_DIR/abi"
-  cp -f "$DAPP_LIB/$lib/out/$class.abi" "$OUT_DIR/abi"
+  cp -f "$DAPP_LIB/$lib/out/*.abi" "$OUT_DIR/abi"
 }
 
 # Start verbose output

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -62,8 +62,8 @@ dappCreate() {
   local lib; lib=$1
   local class; class=$2
   DAPP_OUT="$DAPP_LIB/$lib/out" dapp create "$class" "${@:3}"
-#   mkdir -p "$OUT_DIR/abi"
-#   cp "$DAPP_LIB/$lib/out/$class.abi" "$OUT_DIR/abi"
+  mkdir -p "$OUT_DIR/abi"
+  cp -f "$DAPP_LIB/$lib/out/$class.abi" "$OUT_DIR/abi"
 }
 
 # Start verbose output

--- a/nix/dapp.nix
+++ b/nix/dapp.nix
@@ -207,6 +207,21 @@ let
       src' = fetchGit repo';
       src = "${src'}/src";
     };
+    dsr_1e1a19b = rec {
+      name = "dsr";
+      deps = {
+        ds-test = ds-test_a4e4005;
+        dss = dss_6e5651a;
+      };
+      repo' = {
+        name = "dsr-1e1a19b-source";
+        url = "https://github.com/makerdao/dsr";
+        rev = "1e1a19b341ddf3998933f7944b23a38126c9c409";
+        ref = "HEAD";
+      };
+      src' = fetchGit repo';
+      src = "${src'}/src";
+    };
     ds-roles_0138372 = rec {
       name = "ds-roles";
       deps = {
@@ -237,6 +252,81 @@ let
       src' = fetchGit repo';
       src = "${src'}/src";
     };
+    dss_6e5651a = rec {
+      name = "dss";
+      deps = {
+        ds-test = ds-test_a4e4005;
+        ds-token = ds-token_cee36a1;
+        ds-value = ds-value_f307171;
+      };
+      repo' = {
+        name = "dss-6e5651a-source";
+        url = "https://github.com/makerdao/dss";
+        rev = "6e5651a85d829bed82d1608b67fea87491ee5550";
+        ref = "HEAD";
+      };
+      src' = fetchGit repo';
+      src = "${src'}/src";
+    };
+    dss-cdp-manager_42de124 = rec {
+      name = "dss-cdp-manager";
+      deps = {
+        ds-test = ds-test_a4e4005;
+        dss-deploy = dss-deploy_6be42cf;
+      };
+      repo' = {
+        name = "dss-cdp-manager-42de124-source";
+        url = "https://github.com/makerdao/dss-cdp-manager";
+        rev = "42de1249e2ef269e178590794616e76482e84ea0";
+        ref = "HEAD";
+      };
+      src' = fetchGit repo';
+      src = "${src'}/src";
+    };
+    dss-deploy_133661b = rec {
+      name = "dss-deploy";
+      deps = {
+        ds-auth = ds-auth_f783169;
+        ds-guard = ds-guard_4678e1c;
+        ds-note = ds-note_beef816;
+        ds-pause = ds-pause_e2ac2b0;
+        ds-roles = ds-roles_0138372;
+        ds-test = ds-test_a4e4005;
+        ds-token = ds-token_cee36a1;
+        ds-weth = ds-weth_dfada5b;
+        dsr = dsr_1e1a19b;
+      };
+      repo' = {
+        name = "dss-deploy-133661b-source";
+        url = "https://github.com/makerdao/dss-deploy";
+        rev = "133661bf9ea4b417b2f20d368fdf0eaf0e1a041f";
+        ref = "HEAD";
+      };
+      src' = fetchGit repo';
+      src = "${src'}/src";
+    };
+    dss-deploy_6be42cf = rec {
+      name = "dss-deploy";
+      deps = {
+        ds-auth = ds-auth_f783169;
+        ds-guard = ds-guard_4678e1c;
+        ds-note = ds-note_beef816;
+        ds-pause = ds-pause_e2ac2b0;
+        ds-roles = ds-roles_0138372;
+        ds-test = ds-test_a4e4005;
+        ds-token = ds-token_cee36a1;
+        ds-weth = ds-weth_dfada5b;
+        dsr = dsr_1e1a19b;
+      };
+      repo' = {
+        name = "dss-deploy-6be42cf-source";
+        url = "https://github.com/makerdao/dss-deploy";
+        rev = "6be42cfa7781c86dbf1a1b4013f0583994bfb578";
+        ref = "HEAD";
+      };
+      src' = fetchGit repo';
+      src = "${src'}/src";
+    };
     ds-spell_c908b78 = rec {
       name = "ds-spell";
       deps = {
@@ -248,6 +338,22 @@ let
         name = "ds-spell-c908b78-source";
         url = "https://github.com/dapphub/ds-spell";
         rev = "c908b7807f08661b4eca97adff6d9561d0116244";
+        ref = "HEAD";
+      };
+      src' = fetchGit repo';
+      src = "${src'}/src";
+    };
+    dss-proxy-actions_d28b9f1 = rec {
+      name = "dss-proxy-actions";
+      deps = {
+        ds-proxy = ds-proxy_379f5e2;
+        ds-test = ds-test_a4e4005;
+        dss-cdp-manager = dss-cdp-manager_42de124;
+      };
+      repo' = {
+        name = "dss-proxy-actions-d28b9f1-source";
+        url = "https://github.com/makerdao/dss-proxy-actions";
+        rev = "d28b9f1ac9ba3c02e592772d398d39e3bd745680";
         ref = "HEAD";
       };
       src' = fetchGit repo';
@@ -419,90 +525,6 @@ let
         name = "ds-weth-dfada5b-source";
         url = "https://github.com/dapphub/ds-weth";
         rev = "dfada5bca7a00046c1ddc37c0c43106a8c0a4e5a";
-        ref = "HEAD";
-      };
-      src' = fetchGit repo';
-      src = "${src'}/src";
-    };
-    dsr_1e1a19b = rec {
-      name = "dsr";
-      deps = {
-        ds-test = ds-test_a4e4005;
-        dss = dss_6e5651a;
-      };
-      repo' = {
-        name = "dsr-1e1a19b-source";
-        url = "https://github.com/makerdao/dsr";
-        rev = "1e1a19b341ddf3998933f7944b23a38126c9c409";
-        ref = "HEAD";
-      };
-      src' = fetchGit repo';
-      src = "${src'}/src";
-    };
-    dss-cdp-manager_42de124 = rec {
-      name = "dss-cdp-manager";
-      deps = {
-        ds-test = ds-test_a4e4005;
-        dss-deploy = dss-deploy_6be42cf;
-      };
-      repo' = {
-        name = "dss-cdp-manager-42de124-source";
-        url = "https://github.com/makerdao/dss-cdp-manager";
-        rev = "42de1249e2ef269e178590794616e76482e84ea0";
-        ref = "HEAD";
-      };
-      src' = fetchGit repo';
-      src = "${src'}/src";
-    };
-    dss-deploy_6be42cf = rec {
-      name = "dss-deploy";
-      deps = {
-        ds-auth = ds-auth_f783169;
-        ds-guard = ds-guard_4678e1c;
-        ds-note = ds-note_beef816;
-        ds-pause = ds-pause_e2ac2b0;
-        ds-roles = ds-roles_0138372;
-        ds-test = ds-test_a4e4005;
-        ds-token = ds-token_cee36a1;
-        ds-weth = ds-weth_dfada5b;
-        dsr = dsr_1e1a19b;
-      };
-      repo' = {
-        name = "dss-deploy-6be42cf-source";
-        url = "https://github.com/makerdao/dss-deploy";
-        rev = "6be42cfa7781c86dbf1a1b4013f0583994bfb578";
-        ref = "HEAD";
-      };
-      src' = fetchGit repo';
-      src = "${src'}/src";
-    };
-    dss-proxy-actions_d28b9f1 = rec {
-      name = "dss-proxy-actions";
-      deps = {
-        ds-proxy = ds-proxy_379f5e2;
-        ds-test = ds-test_a4e4005;
-        dss-cdp-manager = dss-cdp-manager_42de124;
-      };
-      repo' = {
-        name = "dss-proxy-actions-d28b9f1-source";
-        url = "https://github.com/makerdao/dss-proxy-actions";
-        rev = "d28b9f1ac9ba3c02e592772d398d39e3bd745680";
-        ref = "HEAD";
-      };
-      src' = fetchGit repo';
-      src = "${src'}/src";
-    };
-    dss_6e5651a = rec {
-      name = "dss";
-      deps = {
-        ds-test = ds-test_a4e4005;
-        ds-token = ds-token_cee36a1;
-        ds-value = ds-value_f307171;
-      };
-      repo' = {
-        name = "dss-6e5651a-source";
-        url = "https://github.com/makerdao/dss";
-        rev = "6e5651a85d829bed82d1608b67fea87491ee5550";
         ref = "HEAD";
       };
       src' = fetchGit repo';
@@ -683,12 +705,12 @@ let
       src' = fetchGit repo';
       src = "${src'}/src";
     };
-    testchain-dss-deployment-scripts_ce01db6 = rec {
+    testchain-dss-deployment-scripts_fc93161 = rec {
       name = "testchain-dss-deployment-scripts";
       deps = {
         ds-chief = ds-chief_58a02ff;
         ds-guard = ds-guard_4678e1c;
-        dss-deploy = dss-deploy_6be42cf;
+        dss-deploy = dss-deploy_133661b;
         dss-proxy-actions = dss-proxy-actions_d28b9f1;
         gov-polling-generator = gov-polling-generator_d08e43e;
         line-spell = line-spell_56fb83a;
@@ -701,15 +723,15 @@ let
         vote-proxy = vote-proxy_ebd7b2f;
       };
       repo' = {
-        name = "testchain-dss-deployment-scripts-ce01db6-source";
+        name = "testchain-dss-deployment-scripts-fc93161-source";
         url = "git@github.com:makerdao/testchain-dss-deployment-scripts";
-        rev = "ce01db6b97aee99a9c7a9d2cd2583ad4b0beaba2";
-        ref = "HEAD";
+        rev = "fc9316179a52f4b528b6678dcda7f4f4a895a025";
+        ref = "add-dss-deploy-to-path";
       };
       src' = fetchGit repo';
       src = "${src'}/src";
     };
-    this = testchain-dss-deployment-scripts_ce01db6 // { src' = ./.; src = ./src; };
+    this = testchain-dss-deployment-scripts_fc93161 // { src' = ../.; src = ../src; };
   };
 in {
   inherit package packageSpecs specs;

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,5 +1,5 @@
 import (fetchGit {
   url = "https://github.com/makerdao/nixpkgs-pin";
-  rev = "a767bd7cbe5f2aea55a1857f2d3e6f8a09a3e1ec";
+  rev = "2927c50733fc557f8c5da17a2229ba851afe171c";
   ref = "master";
 })

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,5 +1,5 @@
 import (fetchGit {
   url = "https://github.com/makerdao/nixpkgs-pin";
-  rev = "475a4ca2eecb8b465eab3a0340874c49a9576deb";
+  rev = "a767bd7cbe5f2aea55a1857f2d3e6f8a09a3e1ec";
   ref = "master";
 })

--- a/poll-deploy
+++ b/poll-deploy
@@ -4,9 +4,8 @@
 . "${LIB_DIR:-$(cd "${0%/*}/lib"&&pwd)}/common.sh"
 
 # Deploy Gov Polling Generator (no solc optimization)
-cd "$DAPP_LIB/gov-polling-generator"
-dapp build
-GOV_POLL_GEN=$(dapp create GovPollingGenerator)
+dappBuild
+GOV_POLL_GEN=$(dappCreate gov-polling-generator GovPollingGenerator)
 
 # tx=$(seth send --async "$GOV_POLL_GEN" 'createPoll()')
 
@@ -34,7 +33,5 @@ addAddresses <<EOF
     "VOTE_NO": "$VOTE_NO"
 }
 EOF
-
-cp "$DAPP_LIB"/gov-polling-generator/out/GovPollingGenerator.abi "$OUT_DIR/abi"
 
 echo "POLL DEPLOYMENT COMPLETED SUCCESSFULLY"

--- a/poll-deploy
+++ b/poll-deploy
@@ -4,7 +4,7 @@
 . "${LIB_DIR:-$(cd "${0%/*}/lib"&&pwd)}/common.sh"
 
 # Deploy Gov Polling Generator (no solc optimization)
-dappBuild
+dappBuild gov-polling-generator
 GOV_POLL_GEN=$(dappCreate gov-polling-generator GovPollingGenerator)
 
 # tx=$(seth send --async "$GOV_POLL_GEN" 'createPoll()')

--- a/scripts/set-ilks-spell-line
+++ b/scripts/set-ilks-spell-line
@@ -8,8 +8,7 @@ CONFIG_FILE="$OUT_DIR/config.json"
 # Get addresses
 loadAddresses
 
-cd "$DAPP_LIB/line-spell"
-dapp build
+dappBuild
 
 tokens=$(jq -r ".tokens | keys_unsorted[]" "$CONFIG_FILE")
 for token in $tokens; do

--- a/scripts/set-ilks-spell-line
+++ b/scripts/set-ilks-spell-line
@@ -8,7 +8,7 @@ CONFIG_FILE="$OUT_DIR/config.json"
 # Get addresses
 loadAddresses
 
-dappBuild
+dappBuild line-spell
 
 tokens=$(jq -r ".tokens | keys_unsorted[]" "$CONFIG_FILE")
 for token in $tokens; do

--- a/step-1-deploy
+++ b/step-1-deploy
@@ -64,11 +64,6 @@ for token in $tokens; do
     fi
 done
 
-# Copy abi files
-cp "$DAPP_LIB"/testchain-medians/out/Median.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/osm/out/DSValue.abi "$OUT_DIR"/abi
-cp "$DAPP_LIB"/osm/out/OSM.abi "$OUT_DIR"/abi
-
 if [[ "$CONFIG_STEP" == "step-1" ]]; then
     "$LIBEXEC_DIR"/set-pause-delay
     echo "STEP 1 COMPLETED SUCCESSFULLY"


### PR DESCRIPTION
This is a suggestion on how to avoid having to explicitly `cd` into `dss-deploy` to use it's scripts. This will also solve the problem discussed here: https://github.com/makerdao/testchain-dss-deployment-scripts/pull/33#issuecomment-494176377

If https://github.com/makerdao/testchain-dss-deployment-scripts/pull/34 is merged we can then remove all regex patching from the Nix derivations.