### PR TITLE
add ETH_FROM to out/addresses.json

### DIFF
--- a/base-deploy
+++ b/base-deploy
@@ -182,6 +182,7 @@ done
 # Generate addresses.json file
 cat > "$OUT_DIR"/addresses.json <<EOF
 {
+    "ETH_FROM": "$ETH_FROM",
     "MULTICALL": "$MULTICALL",
     "FAUCET": "$FAUCET",
     "MCD_DEPLOY": "$MCD_DEPLOY",


### PR DESCRIPTION
Resolves Issue #37 

The Deploy Auth audit tool I am working on updating is expecting `ETH_FROM` to exist in `out/addresses.json`.  This would add that back in.  If there is a more expedient way for an external repo to know `ETH_FROM`, lmk