### PR TITLE
cp abis for DSS-Deploy fabs and DSPause

### DIFF
--- a/base-deploy
+++ b/base-deploy
@@ -160,6 +160,19 @@ cp "$DAPP_LIB"/proxy-registry/out/DSProxy.abi "$OUT_DIR"/abi
 cp "$DAPP_LIB"/proxy-registry/out/DSProxyFactory.abi "$OUT_DIR"/abi
 cp "$DAPP_LIB"/proxy-registry/out/ProxyRegistry.abi "$OUT_DIR"/abi
 cp "$DAPP_LIB"/token-faucet/out/TokenFaucet.abi "$OUT_DIR"/abi
+cp "$DAPP_LIB"/dss-deploy/out/VatFab.abi "$OUT_DIR"/abi
+cp "$DAPP_LIB"/dss-deploy/out/JugFab.abi "$OUT_DIR"/abi
+cp "$DAPP_LIB"/dss-deploy/out/VowFab.abi "$OUT_DIR"/abi
+cp "$DAPP_LIB"/dss-deploy/out/CatFab.abi "$OUT_DIR"/abi
+cp "$DAPP_LIB"/dss-deploy/out/DaiFab.abi "$OUT_DIR"/abi
+cp "$DAPP_LIB"/dss-deploy/out/DaiJoinFab.abi "$OUT_DIR"/abi
+cp "$DAPP_LIB"/dss-deploy/out/FlapFab.abi "$OUT_DIR"/abi
+cp "$DAPP_LIB"/dss-deploy/out/FlopFab.abi "$OUT_DIR"/abi
+cp "$DAPP_LIB"/dss-deploy/out/FlipFab.abi "$OUT_DIR"/abi
+cp "$DAPP_LIB"/dss-deploy/out/SpotFab.abi "$OUT_DIR"/abi
+cp "$DAPP_LIB"/dss-deploy/out/PotFab.abi "$OUT_DIR"/abi
+cp "$DAPP_LIB"/dss-deploy/out/PauseFab.abi "$OUT_DIR"/abi
+cp "$DAPP_LIB"/dss-deploy/out/DSPause.abi "$OUT_DIR"/abi
 
 for token in $tokens; do
     ILKS_VARS+=",

--- a/base-deploy
+++ b/base-deploy
@@ -173,6 +173,7 @@ cp "$DAPP_LIB"/dss-deploy/out/SpotFab.abi "$OUT_DIR"/abi
 cp "$DAPP_LIB"/dss-deploy/out/PotFab.abi "$OUT_DIR"/abi
 cp "$DAPP_LIB"/dss-deploy/out/PauseFab.abi "$OUT_DIR"/abi
 cp "$DAPP_LIB"/dss-deploy/out/DSPause.abi "$OUT_DIR"/abi
+cp "$DAPP_LIB"/dss-deploy/out/Plan.abi "$OUT_DIR"/abi
 
 for token in $tokens; do
     ILKS_VARS+=",


### PR DESCRIPTION
The ABIs for DSS-Deploy and DSPause were not getting copied over to the `out/abi` dir.  This adds those into `base-deploy`. 

(*note: I do not believe this PR is necessary if #34 from @icetan gets merged in first.)