### PR TITLE
add MCD_PAUSE_PROXY to addresses.json

### DIFF
--- a/scripts/base-deploy
+++ b/scripts/base-deploy
@@ -165,6 +165,7 @@ cat > "$OUT_DIR"/addresses.json <<EOF
     "MCD_FLAP": "$MCD_FLAP",
     "MCD_FLOP": "$MCD_FLOP",
     "MCD_PAUSE": "$MCD_PAUSE",
+    "MCD_PAUSE_PROXY": "$MCD_PAUSE_PROXY",
     "MCD_GOV_ACTIONS": "$MCD_GOV_ACTIONS",
     "MCD_DAI": "$MCD_DAI",
     "MCD_SPOT": "$MCD_SPOT",


### PR DESCRIPTION
This is dependent on https://github.com/makerdao/dss-deploy/pull/32 getting merged and we should update the dss-deploy submodule here to use this new code. This adds the MCD_PAUSE_PROXY to the `out/addresses.json` file